### PR TITLE
Add `:type` config for setting the default icon type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v0.2.0-dev
+
+#### Breaking Changes
+
+- Replaced `icon/3` with `icon/2`, the `type` argument should be passed as an option instead
+
+#### Enhancements
+
+- Added `:type` to config for setting the default icon type
+
 ## v0.1.1 (2021-05-29)
 
 - All options passed to `icon/3` will be added to the SVG tag as HTML attributes

--- a/README.md
+++ b/README.md
@@ -20,14 +20,26 @@ Then run `mix deps.get`.
 
 ## Usage
 
-### With Eex or Leex
+#### With Eex or Leex
 
 ```elixir
-<%= Fontawesome.icon("regular", "address-book", class: "h-4 w-4") %>
+<%= Fontawesome.icon("address-book", type: "regular", class: "h-4 w-4") %>
 ```
 
-### With Surface
+#### With Surface
 
 ```elixir
-<Fontawesome.Components.Icon type="regular" name="address-book" class="h-4 w-4" />
+<Fontawesome.Components.Icon name="address-book" type="regular" class="h-4 w-4" />
 ```
+
+## Config
+
+Defaults can be set in the `FontAwesome` application configuration.
+
+```elixir
+config :ex_fontawesome, type: "regular"
+```
+
+## License
+
+MIT. See [LICENSE](https://github.com/miguel-s/ex_fontawesome/blob/master/LICENSE) for more details.

--- a/lib/fontawesome.ex
+++ b/lib/fontawesome.ex
@@ -18,13 +18,20 @@ defmodule FontAwesome do
 
   ## Usage
 
-  ### With Eex or Leex
+  #### With Eex or Leex
 
-      <%= Fontawesome.icon("regular", "address-book", class: "h-4 w-4") %>
+      <%= Fontawesome.icon("address-book", type: "regular", class: "h-4 w-4") %>
 
-  ### With Surface
+  #### With Surface
 
-      <Fontawesome.Components.Icon type="regular" name="address-book" class="h-4 w-4" />
+      <Fontawesome.Components.Icon name="address-book" type="regular" class="h-4 w-4" />
+
+  ## Config
+
+  Defaults can be set in the `FontAwesome` application configuration.
+
+      config :ex_hfontawesome, type: "regular"
+
   """
 
   alias __MODULE__.Icon
@@ -37,35 +44,77 @@ defmodule FontAwesome do
       Icon.parse!(icon_path)
     end
 
+  types = icons |> Enum.map(& &1.type) |> Enum.uniq()
+
+  @types types
+
+  @doc false
+  def types(), do: @types
+
+  @doc false
+  def default_type() do
+    case Application.get_env(:ex_fontawesome, :type) do
+      nil ->
+        nil
+
+      type when is_binary(type) ->
+        if type in types() do
+          type
+        else
+          raise ArgumentError,
+                "expected default type to be one of #{inspect(types())}, got: #{inspect(type)}"
+        end
+
+      type ->
+        raise ArgumentError,
+              "expected default type to be one of #{inspect(types())}, got: #{inspect(type)}"
+    end
+  end
+
   @doc """
   Generates an icon.
 
-  All options are forwarded to the underlying SVG tag as HTML attributes.
+  Options may be passed through to the SVG tag for custom attributes.
 
   ## Options
 
+    * `:type` - the icon type. Accepted values are #{inspect(types)}. Required if default type is not configured.
     * `:class` - the css class added to the SVG tag
 
   ## Examples
 
-      icon("regular", "address-book", class: "h-4 w-4")
+      icon("address-book", type: "regular", class: "h-4 w-4")
       #=> <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
             <!-- Font Awesome Free 5.15.3 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) -->
             <path d="M436 160c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20V48c0-26.5-21.5-48-48-48H48C21.5 0 0 21.5 0 48v416c0 26.5 21.5 48 48 48h320c26.5 0 48-21.5 48-48v-48h20c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20v-64h20c6.6 0 12-5.4 12-12v-40c0-6.6-5.4-12-12-12h-20v-64h20zm-68 304H48V48h320v416zM208 256c35.3 0 64-28.7 64-64s-28.7-64-64-64-64 28.7-64 64 28.7 64 64 64zm-89.6 128h179.2c12.4 0 22.4-8.6 22.4-19.2v-19.2c0-31.8-30.1-57.6-67.2-57.6-10.8 0-18.7 8-44.8 8-26.9 0-33.4-8-44.8-8-37.1 0-67.2 25.8-67.2 57.6v19.2c0 10.6 10 19.2 22.4 19.2z"/>
           </svg>
   """
-  @spec icon(String.t(), String.t(), keyword) :: Phoenix.HTML.safe()
-  def icon(type, name, opts \\ [])
+  @spec icon(String.t(), keyword) :: Phoenix.HTML.safe()
+  def icon(name, opts \\ []) when is_binary(name) and is_list(opts) do
+    {type, opts} = Keyword.pop(opts, :type, default_type())
+
+    unless type do
+      raise ArgumentError,
+            "expected type in options, got: #{inspect(opts)}"
+    end
+
+    unless type in types() do
+      raise ArgumentError,
+            "expected type to be one of #{inspect(types())}, got: #{inspect(type)}"
+    end
+
+    icon(type, name, opts)
+  end
 
   for %Icon{type: type, name: name, file: file} <- icons do
-    def icon(unquote(type), unquote(name), opts) do
+    defp icon(unquote(type), unquote(name), opts) do
       attrs = Icon.opts_to_attrs(opts)
       Icon.insert_attrs(unquote(file), attrs)
     end
   end
 
-  def icon(type, name, _opts) do
+  defp icon(type, name, _opts) do
     raise ArgumentError,
-          "icon of type #{inspect(type)} with name #{inspect(name)} does not exist."
+          "icon #{inspect(name)} with type #{inspect(type)} does not exist."
   end
 end

--- a/lib/fontawesome/components/icon.ex
+++ b/lib/fontawesome/components/icon.ex
@@ -5,16 +5,20 @@ if Code.ensure_loaded?(Surface) do
 
     ## Examples
 
-        <FontAwesome.Components.Icon type="regular" name="address-book" class="h-4 w-4" />
+        <FontAwesome.Components.Icon name="address-book" type="regular" class="h-4 w-4" />
     """
 
     use Surface.Component
 
-    @doc "The type of the icon"
-    prop type, :string, values: ["brand", "regular", "solid"], required: true
-
     @doc "The name of the icon"
     prop name, :string, required: true
+
+    @doc """
+    The type of the icon
+
+    Required if default type is not configured.
+    """
+    prop type, :string
 
     @doc "The class of the icon"
     prop class, :css_class
@@ -23,17 +27,27 @@ if Code.ensure_loaded?(Surface) do
     prop opts, :keyword, default: []
 
     def render(assigns) do
-      opts = class_to_opts(assigns) ++ assigns.opts
-
       ~H"""
-      {{ FontAwesome.icon(@type, @name, opts) }}
+      {{ FontAwesome.icon(@name, type_to_opts(@type) ++ class_to_opts(@class) ++ @opts) }}
       """
     end
 
-    defp class_to_opts(assigns) do
-      case Map.get(assigns, :class) do
-        nil -> []
-        class -> [class: Surface.css_class(class)]
+    defp type_to_opts(type) do
+      type = type || FontAwesome.default_type()
+
+      unless type do
+        raise ArgumentError,
+              "type prop is required if default type is not configured."
+      end
+
+      [type: type]
+    end
+
+    defp class_to_opts(class) do
+      if class do
+        [class: Surface.css_class(class)]
+      else
+        []
       end
     end
   end

--- a/lib/fontawesome/icon.ex
+++ b/lib/fontawesome/icon.ex
@@ -6,7 +6,7 @@ defmodule FontAwesome.Icon do
   alias __MODULE__
 
   @doc """
-  Defines the Heroicons.Icon struct.
+  Defines the FontAwesome.Icon struct.
 
   Its fields are:
 

--- a/test/components/icon_test.exs
+++ b/test/components/icon_test.exs
@@ -14,7 +14,7 @@ defmodule FontAwesome.Components.IconTest do
 
     def render(assigns) do
       ~H"""
-      <Icon type="regular" name="address-book" opts={{ aria_hidden: @aria_hidden }} />
+      <Icon name="address-book" type="regular" opts={{ aria_hidden: @aria_hidden }} />
       """
     end
   end
@@ -23,7 +23,7 @@ defmodule FontAwesome.Components.IconTest do
     html =
       render_surface do
         ~H"""
-        <Icon type="regular" name="address-book" />
+        <Icon name="address-book" type="regular" />
         """
       end
 
@@ -34,7 +34,7 @@ defmodule FontAwesome.Components.IconTest do
     html =
       render_surface do
         ~H"""
-        <Icon type="regular" name="address-book" class="h-4 w-4" />
+        <Icon name="address-book" type="regular" class="h-4 w-4" />
         """
       end
 
@@ -45,7 +45,7 @@ defmodule FontAwesome.Components.IconTest do
     html =
       render_surface do
         ~H"""
-        <Icon type="regular" name="address-book" opts={{ aria_hidden: true }} />
+        <Icon name="address-book" type="regular" opts={{ aria_hidden: true }} />
         """
       end
 
@@ -56,30 +56,44 @@ defmodule FontAwesome.Components.IconTest do
     html =
       render_surface do
         ~H"""
-        <Icon type="regular" name="address-book" class="hello" opts={{ class: "world" }} />
+        <Icon name="address-book" type="regular" class="hello" opts={{ class: "world" }} />
         """
       end
 
     assert html =~ ~s(<svg class="hello")
   end
 
-  test "raises if type or icon don't exist" do
-    msg = ~s(icon of type "hello" with name "address-book" does not exist.)
+  test "raises if icon name does not exist" do
+    msg = ~s(icon "hello" with type "regular" does not exist.)
 
     assert_raise ArgumentError, msg, fn ->
       render_surface do
         ~H"""
-        <Icon type="hello" name="address-book" />
+        <Icon name="hello" type="regular" />
         """
       end
     end
+  end
 
-    msg = ~s(icon of type "regular" with name "world" does not exist.)
+  test "raises if type is missing" do
+    msg = ~s(type prop is required if default type is not configured.)
 
     assert_raise ArgumentError, msg, fn ->
       render_surface do
         ~H"""
-        <Icon type="regular" name="world" />
+        <Icon name="hello" />
+        """
+      end
+    end
+  end
+
+  test "raises if icon type does not exist" do
+    msg = ~s(expected type to be one of #{inspect(FontAwesome.types())}, got: "world")
+
+    assert_raise ArgumentError, msg, fn ->
+      render_surface do
+        ~H"""
+        <Icon name="address-book" type="world" />
         """
       end
     end
@@ -95,5 +109,38 @@ defmodule FontAwesome.Components.IconTest do
 
     assert render_click(view, :toggle_aria_hidden) =~
              ~s(<svg aria-hidden="false")
+  end
+end
+
+defmodule FontAwesome.Components.IconConfigTest do
+  use FontAwesome.ConnCase
+
+  alias FontAwesome.Components.Icon
+
+  test "renders icon with default type" do
+    Application.put_env(:ex_fontawesome, :type, "regular")
+
+    html =
+      render_surface do
+        ~H"""
+        <Icon name="address-book" />
+        """
+      end
+
+    assert html =~ "<svg"
+  end
+
+  test "raises if default icon type does not exist" do
+    Application.put_env(:ex_fontawesome, :type, "world")
+
+    msg = ~s(expected default type to be one of #{inspect(FontAwesome.types())}, got: "world")
+
+    assert_raise ArgumentError, msg, fn ->
+      render_surface do
+        ~H"""
+        <Icon name="address-book" />
+        """
+      end
+    end
   end
 end

--- a/test/fontawesome_test.exs
+++ b/test/fontawesome_test.exs
@@ -3,31 +3,62 @@ defmodule FontAwesomeTest do
   doctest FontAwesome
 
   test "renders icon" do
-    assert FontAwesome.icon("regular", "address-book")
+    assert FontAwesome.icon("address-book", type: "regular")
            |> Phoenix.HTML.safe_to_string() =~ "<svg"
   end
 
   test "renders icon with attribute" do
-    assert FontAwesome.icon("regular", "address-book", class: "h-4 w-4")
+    assert FontAwesome.icon("address-book", type: "regular", class: "h-4 w-4")
            |> Phoenix.HTML.safe_to_string() =~ ~s(<svg class="h-4 w-4")
   end
 
   test "converts opts to attributes" do
-    assert FontAwesome.icon("regular", "address-book", aria_hidden: true)
+    assert FontAwesome.icon("address-book", type: "regular", aria_hidden: true)
            |> Phoenix.HTML.safe_to_string() =~ ~s(<svg aria-hidden="true")
   end
 
-  test "raises if type or icon don't exist" do
-    msg = ~s(icon of type "hello" with name "address-book" does not exist.)
+  test "raises if icon name does not exist" do
+    msg = ~s(icon "hello" with type "regular" does not exist.)
 
     assert_raise ArgumentError, msg, fn ->
-      FontAwesome.icon("hello", "address-book")
+      FontAwesome.icon("hello", type: "regular")
     end
+  end
 
-    msg = ~s(icon of type "regular" with name "world" does not exist.)
+  test "raises if type is missing" do
+    msg = ~s(expected type in options, got: [])
 
     assert_raise ArgumentError, msg, fn ->
-      FontAwesome.icon("regular", "world")
+      FontAwesome.icon("address-book")
+    end
+  end
+
+  test "raises if icon type does not exist" do
+    msg = ~s(expected type to be one of #{inspect(FontAwesome.types())}, got: "world")
+
+    assert_raise ArgumentError, msg, fn ->
+      FontAwesome.icon("address-book", type: "world")
+    end
+  end
+end
+
+defmodule FontAwesomeConfigTest do
+  use ExUnit.Case
+
+  test "renders icon with default type" do
+    Application.put_env(:ex_fontawesome, :type, "regular")
+
+    assert FontAwesome.icon("address-book")
+           |> Phoenix.HTML.safe_to_string() =~ "<svg"
+  end
+
+  test "raises if default icon type does not exist" do
+    Application.put_env(:ex_fontawesome, :type, "world")
+
+    msg = ~s(expected default type to be one of #{inspect(FontAwesome.types())}, got: "world")
+
+    assert_raise ArgumentError, msg, fn ->
+      FontAwesome.icon("address-book")
     end
   end
 end


### PR DESCRIPTION
This PR introduces the `:type` config for setting the default icon type.

#### Goal

Improve DX by removing the need to repeat the (default) type each time an icon is used.

#### Usage

In your `config.exs` add:

```elixir
config :ex_fontawesome, type: "regular" # or "solid" or "brands"
```

Which will allow to omit the `type` option/prop:

Eex and Leex
```elixir
<%= FontAwesome.icon("address-book", class: "h-4 w-4") %>
```

Surface
```elixir
<FontAwesome.Components.Icon name="address-book" class="h-4 w-4" />
```

#### Breaking Changes

Replaced `icon/3` with `icon/2`, the `type` argument should be passed as an option instead.

Before
```elixir
FontAwesome.icon("regular", "address-book", class: "h-4 w-4")
```

After
```elixir
FontAwesome.icon("address-book", type: "regular", class: "h-4 w-4")
```